### PR TITLE
chore: Fix build entrypoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+throw new Error(
+  'This package is published to npm so that the static files can be hosted locally for testing. This package cannot be run directly.',
+);

--- a/package.json
+++ b/package.json
@@ -10,26 +10,9 @@
     "type": "git",
     "url": "https://github.com/MetaMask/test-dapp-multichain.git"
   },
-  "sideEffects": false,
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
-    },
-    "./package.json": "./package.json"
-  },
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.cts",
+  "main": "index.js",
   "files": [
-    "dist"
+    "dist/"
   ],
   "scripts": {
     "build": "react-scripts build",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "type": "git",
     "url": "https://github.com/MetaMask/test-dapp-multichain.git"
   },
-  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
+  "main": "./index.js",
   "files": [
     "dist/"
   ],

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -241,18 +241,9 @@ module.exports = defineConfig({
     // The package must specify a minimum Node.js version of 18.18.
     workspace.set('engines.node', '^18.18 || >=20');
 
-    // The package must provide the location of the CommonJS-compatible
-    // entrypoint and its matching type declaration file.
-    workspace.set('main', './dist/index.cjs');
-    workspace.set('exports["."].require.default', './dist/index.cjs');
-    workspace.set('types', './dist/index.d.cts');
-    workspace.set('exports["."].require.types', './dist/index.d.cts');
-
-    // The package must provide the location of the ESM-compatible JavaScript
-    // entrypoint and its matching type declaration file.
-    workspace.set('module', './dist/index.mjs');
-    workspace.set('exports["."].import.default', './dist/index.mjs');
-    workspace.set('exports["."].import.types', './dist/index.d.mts');
+    // The package must provide the location of the entrypoint and its matching
+    // type declaration file.
+    workspace.set('main', './index.js');
 
     // The package must export a `package.json` file.
     workspace.set('exports["./package.json"]', './package.json');
@@ -261,7 +252,7 @@ module.exports = defineConfig({
 
     // The list of files included in the package must only include files
     // generated during the build process.
-    workspace.set('files', ['dist']);
+    workspace.set('files', ['dist/']);
 
     // The package is public, and should be published to the npm registry.
     workspace.unset('private');


### PR DESCRIPTION
* Add dummy `index.js`
* Points `package.json` to that entrypoint