### PR TITLE
Multichain Test Dapp: Add (multi)input to request accounts in `wallet_createSession` call #23

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -415,10 +415,6 @@ function App() {
   return (
     <div className="App">
       <h1>MetaMask MultiChain API Test Dapp</h1>
-      <DynamicAddressInputs
-        inputArray={addresses}
-        setInputArray={setAddresses}
-      />
       <div className="app-subtitle">
         <i>Requires MetaMask Extension with CAIP Multichain API Enabled</i>
       </div>
@@ -527,6 +523,12 @@ function App() {
                       disabled={!isExternallyConnectableConnected}
                     />
                   </label>
+                </div>
+                <div>
+                  <DynamicAddressInputs
+                    inputArray={addresses}
+                    setInputArray={setAddresses}
+                  />
                 </div>
                 <div className="session-lifecycle-buttons">
                   <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { parseOpenRPCDocument } from '@open-rpc/schema-utils-js';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import './App.css';
+import DynamicAddressInputs from './components/DynamicAddressInputs';
 import WalletList from './components/WalletList';
 import type { WalletMapEntry } from './components/WalletList';
 import {
@@ -18,6 +19,7 @@ import { openRPCExampleToJSON, truncateJSON } from './helpers/JsonHelpers';
 import { useSDK } from './sdk';
 
 function App() {
+  const [addresses, setAddresses] = useState<string[]>(['']);
   const [walletMapEntries, setWalletMapEntries] = useState<
     Record<string, WalletMapEntry>
   >({});
@@ -410,6 +412,11 @@ function App() {
   return (
     <div className="App">
       <h1>MetaMask MultiChain API Test Dapp</h1>
+      <DynamicAddressInputs
+        inputArray={addresses}
+        setInputArray={setAddresses}
+        onSubmit={() => console.log({ addresses })}
+      />
       <div className="app-subtitle">
         <i>Requires MetaMask Extension with CAIP Multichain API Enabled</i>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -240,7 +240,10 @@ function App() {
       (scope) => selectedScopes[scope as CaipChainId],
     );
     try {
-      const result = await createSession(selectedScopesArray as CaipChainId[]);
+      const result = await createSession(
+        selectedScopesArray as CaipChainId[],
+        addresses,
+      );
       setSessionMethodHistory((prev) => {
         const timestamp = Date.now();
         if (prev.some((entry) => entry.timestamp === timestamp)) {
@@ -415,7 +418,6 @@ function App() {
       <DynamicAddressInputs
         inputArray={addresses}
         setInputArray={setAddresses}
-        onSubmit={() => console.log({ addresses })}
       />
       <div className="app-subtitle">
         <i>Requires MetaMask Extension with CAIP Multichain API Enabled</i>

--- a/src/components/DynamicAddressInputs.tsx
+++ b/src/components/DynamicAddressInputs.tsx
@@ -3,13 +3,11 @@ import React, { useCallback } from 'react';
 type DynamicInputsProps = {
   inputArray: string[];
   setInputArray: React.Dispatch<React.SetStateAction<string[]>>;
-  onSubmit: (inputs: string[]) => void;
 };
 
 const DynamicAddressInputs: React.FC<DynamicInputsProps> = ({
   inputArray,
   setInputArray,
-  onSubmit,
 }) => {
   const handleInputChange = useCallback(
     (index: number, value: string) => {
@@ -45,7 +43,6 @@ const DynamicAddressInputs: React.FC<DynamicInputsProps> = ({
           )}
         </div>
       ))}
-      <button onClick={() => onSubmit(inputArray)}>Submit</button>
     </div>
   );
 };

--- a/src/components/DynamicAddressInputs.tsx
+++ b/src/components/DynamicAddressInputs.tsx
@@ -1,0 +1,53 @@
+import React, { useCallback } from 'react';
+
+type DynamicInputsProps = {
+  inputArray: string[];
+  setInputArray: React.Dispatch<React.SetStateAction<string[]>>;
+  onSubmit: (inputs: string[]) => void;
+};
+
+const DynamicAddressInputs: React.FC<DynamicInputsProps> = ({
+  inputArray,
+  setInputArray,
+  onSubmit,
+}) => {
+  const handleInputChange = useCallback(
+    (index: number, value: string) => {
+      const newInputs = [...inputArray];
+      newInputs[index] = value;
+      setInputArray(newInputs);
+    },
+    [inputArray, setInputArray],
+  );
+
+  const addInput = () => {
+    if (inputArray.length < 5) {
+      setInputArray([...inputArray, '']);
+    }
+  };
+
+  return (
+    <div>
+      {inputArray.map((input, index) => (
+        <div key={index}>
+          <input
+            type="text"
+            value={input}
+            onChange={(inputEvent) =>
+              handleInputChange(index, inputEvent.target.value)
+            }
+            placeholder={`Input ${index + 1}`}
+          />
+          {index === inputArray.length - 1 && inputArray.length < 5 && (
+            <button onClick={addInput} disabled={!input}>
+              +
+            </button>
+          )}
+        </div>
+      ))}
+      <button onClick={() => onSubmit(inputArray)}>Submit</button>
+    </div>
+  );
+};
+
+export default DynamicAddressInputs;

--- a/src/components/DynamicAddressInputs.tsx
+++ b/src/components/DynamicAddressInputs.tsx
@@ -18,24 +18,27 @@ const DynamicAddressInputs: React.FC<DynamicInputsProps> = ({
     [inputArray, setInputArray],
   );
 
-  const addInput = () => {
+  const addInput = useCallback(() => {
     if (inputArray.length < 5) {
       setInputArray([...inputArray, '']);
     }
-  };
+  }, [setInputArray, inputArray]);
 
   return (
     <div>
       {inputArray.map((input, index) => (
         <div key={index}>
-          <input
-            type="text"
-            value={input}
-            onChange={(inputEvent) =>
-              handleInputChange(index, inputEvent.target.value)
-            }
-            placeholder={`Input ${index + 1}`}
-          />
+          <label>
+            Address:
+            <input
+              type="text"
+              value={input}
+              onChange={(inputEvent) =>
+                handleInputChange(index, inputEvent.target.value)
+              }
+              placeholder="0x483b...5f97"
+            />
+          </label>
           {index === inputArray.length - 1 && inputArray.length < 5 && (
             <button onClick={addInput} disabled={!input}>
               +

--- a/src/helpers/AddressHelpers.ts
+++ b/src/helpers/AddressHelpers.ts
@@ -1,0 +1,7 @@
+// TODO: validate EVM address ?
+export const getCreateSessionOptionalScopesFormattedAddresses = (
+  scope: string,
+  addresses: string[],
+): string[] => {
+  return addresses.map((address) => scope.concat(`:${address}`));
+};

--- a/src/helpers/AddressHelpers.ts
+++ b/src/helpers/AddressHelpers.ts
@@ -1,7 +1,7 @@
 /**
- * Formats addresses with respective scope to create a session. See [CAIP-25](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-25.md).
+ * Formats addresses as [CAIP-10](https://chainagnostic.org/CAIPs/caip-10) addresses for it's respective request scope. See [CAIP-25](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-25.md) and .
  * @param scope - The scope to create session for.
- * @param addresses - The addresses to create session for. If address is empty, we remove it from the array.
+ * @param addresses - The addresses to format. If address is empty, we remove it from the array.
  * @returns The formatted addresses with the scope to create session for.
  */
 export const getCreateSessionOptionalScopesFormattedAddresses = (

--- a/src/helpers/AddressHelpers.ts
+++ b/src/helpers/AddressHelpers.ts
@@ -4,7 +4,7 @@
  * @param addresses - The addresses to format. If address is empty, we remove it from the array.
  * @returns The formatted addresses with the scope to create session for.
  */
-export const getCreateSessionOptionalScopesFormattedAddresses = (
+export const getCaip25FormattedAddresses = (
   scope: string,
   addresses: string[],
 ): string[] => {

--- a/src/helpers/AddressHelpers.ts
+++ b/src/helpers/AddressHelpers.ts
@@ -1,7 +1,17 @@
-// TODO: validate EVM address ?
+/**
+ * Formats addresses with respective scope to create a session. See [CAIP-25](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-25.md).
+ * @param scope - The scope to create session for.
+ * @param addresses - The addresses to create session for. If address is empty, we remove it from the array.
+ * @returns The formatted addresses with the scope to create session for.
+ */
 export const getCreateSessionOptionalScopesFormattedAddresses = (
   scope: string,
   addresses: string[],
 ): string[] => {
-  return addresses.map((address) => scope.concat(`:${address}`));
+  return addresses.reduce<string[]>((result, address) => {
+    if (address.length > 0) {
+      result.push(`${scope}:${address}`);
+    }
+    return result;
+  }, []);
 };

--- a/src/sdk/SDK.ts
+++ b/src/sdk/SDK.ts
@@ -2,6 +2,7 @@ import type { CaipChainId, Json } from '@metamask/utils';
 import { parseCaipChainId, KnownCaipNamespace } from '@metamask/utils';
 
 import { Eip155Notifications, Eip155Methods } from '../constants/methods';
+import { getCreateSessionOptionalScopesFormattedAddresses } from '../helpers/AddressHelpers';
 import MetaMaskMultichainProvider from './providers/MetaMaskMultichainProvider';
 
 export const METAMASK_PROD_CHROME_ID = 'nkbihfbeogaeaoehlefnkodbefgpgknn';
@@ -16,9 +17,15 @@ export class SDK {
     this.#extensionId = METAMASK_PROD_CHROME_ID;
   }
 
-  public async createSession(scopes: CaipChainId[]): Promise<Json> {
+  public async createSession(
+    scopes: CaipChainId[],
+    addresses: string[],
+  ): Promise<Json> {
     const optionalScopes = scopes.reduce<
-      Record<CaipChainId, { methods: string[]; notifications: string[] }>
+      Record<
+        CaipChainId,
+        { methods: string[]; notifications: string[]; accounts: string[] }
+      >
     >((acc, scope) => {
       const { reference, namespace } = parseCaipChainId(scope);
       // if this is an EVM chain, prepopulate the createSession request all the EIP155 methods and notifications that we support
@@ -26,24 +33,31 @@ export class SDK {
         acc[scope] = {
           methods: Eip155Methods,
           notifications: Eip155Notifications,
+          accounts: getCreateSessionOptionalScopesFormattedAddresses(
+            scope,
+            addresses,
+          ),
         };
       } else if (namespace === KnownCaipNamespace.Solana) {
         // TODO: add solana methods and notifications that our Solana snap supports
         // acc[scope] = {
         //   methods: SolanaMethods,
         //   notifications: SolanaNotifications,
+        //   accounts: SolanaAccounts,
         // };
       } else if (namespace === KnownCaipNamespace.Bip122) {
         // TODO: add bip122 methods and notifications that our Bitcoin snap supports
         // acc[scope] = {
         //   methods: Bip122Methods,
         //   notifications: Bip122Notifications,
+        //   accounts: Bip122Accounts,
         // };
       } else {
         // Any other chains we don't know the API for beforehand,
         acc[scope] = {
           methods: [],
           notifications: [],
+          accounts: [],
         };
       }
       return acc;

--- a/src/sdk/SDK.ts
+++ b/src/sdk/SDK.ts
@@ -2,7 +2,7 @@ import type { CaipChainId, Json } from '@metamask/utils';
 import { parseCaipChainId, KnownCaipNamespace } from '@metamask/utils';
 
 import { Eip155Notifications, Eip155Methods } from '../constants/methods';
-import { getCreateSessionOptionalScopesFormattedAddresses } from '../helpers/AddressHelpers';
+import { getCaip25FormattedAddresses } from '../helpers/AddressHelpers';
 import MetaMaskMultichainProvider from './providers/MetaMaskMultichainProvider';
 
 export const METAMASK_PROD_CHROME_ID = 'nkbihfbeogaeaoehlefnkodbefgpgknn';
@@ -33,10 +33,7 @@ export class SDK {
         acc[scope] = {
           methods: Eip155Methods,
           notifications: Eip155Notifications,
-          accounts: getCreateSessionOptionalScopesFormattedAddresses(
-            scope,
-            addresses,
-          ),
+          accounts: getCaip25FormattedAddresses(scope, addresses),
         };
       } else if (namespace === KnownCaipNamespace.Solana) {
         // TODO: add solana methods and notifications that our Solana snap supports

--- a/src/sdk/useSDK.ts
+++ b/src/sdk/useSDK.ts
@@ -9,7 +9,7 @@ type UseSDKReturn = {
   extensionId: string;
   connect: (extensionId: string) => Promise<void>;
   disconnect: () => void;
-  createSession: (scopes: CaipChainId[]) => Promise<Json>;
+  createSession: (scopes: CaipChainId[], addresses: string[]) => Promise<Json>;
   getSession: () => Promise<Json>;
   revokeSession: () => Promise<Json>;
   invokeMethod: (
@@ -157,11 +157,11 @@ export function useSDK({
   }, [sdk]);
 
   const createSession = useCallback(
-    async (scopes: CaipChainId[]) => {
+    async (scopes: CaipChainId[], addresses: string[]) => {
       if (!sdk) {
         throw new Error('SDK not initialized');
       }
-      const result = await sdk.createSession(scopes);
+      const result = await sdk.createSession(scopes, addresses);
       console.log('result', result);
       setCurrentSession(result);
       return result;


### PR DESCRIPTION
We are now adding addresses to the `optionalScopes` `accounts` param seen in example below such
```
{
  "method": "wallet_createSession",
  "params": {
    "optionalScopes": {
      "eip155:1": {
        "methods": [<all methods>],
        "notifications": [<all_notifcations>]
        "accounts": ["eip155:1:0xE7d522230eFf653Bb0a9B4385F0be0815420Dd98"]
      },
      "eip155:10": {
       "methods": [<all methods>],
       "notifications": [<all_notifcations>]
       "accounts": ["eip155:10:0xE7d522230eFf653Bb0a9B4385F0be0815420Dd98"]
      },
  }
}
```

Steps to test:
-- Connect to MetaMask wallet
-- Populate address input box (optionally can populate multiple by pressing `+` button to add a new one, up to 5 max)
-- Press `wallet_createSession`, and addresses should be populated as [CAIP-10](https://chainagnostic.org/CAIPs/caip-10) addresses on each of the requested scope objects.


https://github.com/user-attachments/assets/c343207f-0878-44b1-ba3c-053f6d0c39f5



<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
