### PR TITLE
move deps into devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,26 +45,21 @@
       "last 1 safari version"
     ]
   },
-  "dependencies": {
+  "devDependencies": {
+    "@lavamoat/allow-scripts": "^3.0.4",
+    "@lavamoat/preinstall-always-fail": "^2.0.0",
     "@metamask/api-specs": "^0.10.12",
+    "@metamask/auto-changelog": "^3.4.3",
+    "@metamask/eslint-config": "^12.2.0",
+    "@metamask/eslint-config-jest": "^12.1.0",
+    "@metamask/eslint-config-nodejs": "^12.1.0",
+    "@metamask/eslint-config-typescript": "^12.1.0",
     "@metamask/utils": "^11.0.0",
     "@open-rpc/meta-schema": "^1.14.9",
     "@open-rpc/schema-utils-js": "^2.0.5",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@types/chrome": "^0.0.279",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-scripts": "5.0.1"
-  },
-  "devDependencies": {
-    "@lavamoat/allow-scripts": "^3.0.4",
-    "@lavamoat/preinstall-always-fail": "^2.0.0",
-    "@metamask/auto-changelog": "^3.4.3",
-    "@metamask/eslint-config": "^12.2.0",
-    "@metamask/eslint-config-jest": "^12.1.0",
-    "@metamask/eslint-config-nodejs": "^12.1.0",
-    "@metamask/eslint-config-typescript": "^12.1.0",
     "@types/jest": "^28.1.6",
     "@types/node": "^18.18",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
@@ -82,6 +77,9 @@
     "jest": "^28.1.3",
     "prettier": "^2.7.1",
     "prettier-plugin-packagejson": "^2.3.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-scripts": "5.0.1",
     "ts-node": "^10.7.0",
     "typescript": "~4.8.4"
   },


### PR DESCRIPTION
Hopefully solves the lavamoat issues we're having downstream. Also aligns us with what test-dapp and test-snaps do