### PR TITLE
feat: remove caip-x envelope for window postMessage provider

### DIFF
--- a/src/sdk/providers/MetaMaskMultichainWindowPostMessageProvider.ts
+++ b/src/sdk/providers/MetaMaskMultichainWindowPostMessageProvider.ts
@@ -22,11 +22,7 @@ class MetaMaskMultichainWindowPostMessageProvider extends MetaMaskMultichainBase
 
     this.#listener = (messageEvent: MessageEvent) => {
       const { target, data } = messageEvent.data;
-      if (
-        target !== INPAGE ||
-        data?.name !== MULTICHAIN_SUBSTREAM_NAME ||
-        data?.data.type !== 'caip-x'
-      ) {
+      if (target !== INPAGE || data?.name !== MULTICHAIN_SUBSTREAM_NAME) {
         return;
       }
       this._handleMessage(data.data.data);
@@ -54,10 +50,7 @@ class MetaMaskMultichainWindowPostMessageProvider extends MetaMaskMultichainBase
         target: CONTENT_SCRIPT,
         data: {
           name: MULTICHAIN_SUBSTREAM_NAME,
-          data: {
-            type: 'caip-x',
-            data: request,
-          },
+          data: request,
         },
       },
       location.origin,


### PR DESCRIPTION
Removes the `{type: 'caip-x', data: ...}` envelope from the window.postMessage provider