### PR TITLE
feat: add support for calling EIP-5792 methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.4",
     "@lavamoat/preinstall-always-fail": "^2.0.0",
-    "@metamask/api-specs": "^0.10.12",
+    "@metamask/api-specs": "^0.14.0",
     "@metamask/auto-changelog": "^3.4.3",
     "@metamask/eslint-config": "^12.2.0",
     "@metamask/eslint-config-jest": "^12.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,10 +2542,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/api-specs@npm:^0.10.12":
-  version: 0.10.12
-  resolution: "@metamask/api-specs@npm:0.10.12"
-  checksum: 10/e592f27f350994688d3d54a8a8db16de033011ef665efe3283a77431914d8d69d1c3312fad33e4245b4984e1223b04c98da3d0a68c7f9577cf8290ba441c52ee
+"@metamask/api-specs@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "@metamask/api-specs@npm:0.14.0"
+  checksum: 10/6caad5e233c12b87f25313fe1e0fb35af6ad9f0ef49e105b36a1826bd8b611a9335642920ddb6c556343375db4b02138a32598b7185392e50050ae7f390e0e7d
   languageName: node
   linkType: hard
 
@@ -2627,7 +2627,7 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
     "@lavamoat/preinstall-always-fail": "npm:^2.0.0"
-    "@metamask/api-specs": "npm:^0.10.12"
+    "@metamask/api-specs": "npm:^0.14.0"
     "@metamask/auto-changelog": "npm:^3.4.3"
     "@metamask/eslint-config": "npm:^12.2.0"
     "@metamask/eslint-config-jest": "npm:^12.1.0"


### PR DESCRIPTION
This PR enables calling EIP-5792 methods from the Test Dapp by:
- bumping `@metamask/api-specs`  to `v0.14.0`
- adding `wallet_sendCalls` and `wallet_getCapabilities` method param injection.

Required for https://github.com/MetaMask/MetaMask-planning/issues/4784

![Screenshot 2025-05-19 at 12 59 40](https://github.com/user-attachments/assets/a8f254ea-1d0c-4aeb-8465-59118c5400a5)


