### PR TITLE
feat: Adds Bitcoin to the list of networks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,7 @@ function App() {
     [FEATURED_NETWORKS['Base Mainnet']]: false,
     [FEATURED_NETWORKS.Localhost]: false,
     [FEATURED_NETWORKS['Solana Mainnet']]: false,
+    [FEATURED_NETWORKS.Bitcoin]: false,
   });
   const [extensionId, setExtensionId] = useState<string>('');
   const [invokeMethodRequests, setInvokeMethodRequests] = useState<
@@ -328,6 +329,7 @@ function App() {
       [FEATURED_NETWORKS['Base Mainnet']]: false,
       [FEATURED_NETWORKS.Localhost]: false,
       [FEATURED_NETWORKS['Solana Mainnet']]: false,
+      [FEATURED_NETWORKS.Bitcoin]: false,
     });
   };
 

--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -12,6 +12,7 @@ export const FEATURED_NETWORKS = {
   'Base Mainnet': 'eip155:8453',
   Localhost: 'eip155:1337',
   'Solana Mainnet': 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  Bitcoin: 'bip122:000000000019d6689c085ae165831e93',
 } as const;
 
 export const getNetworkName = (chainId: CaipChainId): string => {


### PR DESCRIPTION
## Summary

This PR adds Bitcoin network support to the test dapp, enabling users to create sessions with Bitcoin wallets using the CAIP-2 chain ID bip122:000000000019d6689c085ae165831e93.

## Changes
- Added Bitcoin to FEATURED_NETWORKS constant in src/constants/networks.ts
- Added Bitcoin checkbox to the create session UI in src/App.tsx
- Bitcoin sessions are created with no methods or notifications

**Note:** this requires a version of Metamask with Bitcoin support. The main branch will work just fine. 

Here's a short video demoing it

https://github.com/user-attachments/assets/ea1bdad6-0be9-4587-8eb0-1c9ec9c6c373

